### PR TITLE
docs(README): add Lenovo IdeaPad 5 2-in-1 Gen 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ this is a standard mechanism for this functionality nowadays. Tested devices:
 - Thinkpad Yoga 11e Gen6
 - Thinkpad X370 Yoga
 - Lenovo IdeaPad Flex 5i Gen 7
+- Lenovo IdeaPad 5 2-in-1 Gen 10 (AMD)
 - Samsung Galaxy Book Flex2 5G
 - Dell XPS 13 9310 2-in-1
 - ASUS ZenBook 15 Flip OLED UP6502ZD


### PR DESCRIPTION
Add Lenovo IdeaPad 5 2-in-1 Gen 10 (14AKP10) to the list of supported devices after confirming functionality.

Tested on openSUSE Tumbleweed